### PR TITLE
fix includes

### DIFF
--- a/utils/pattern_scan.cpp
+++ b/utils/pattern_scan.cpp
@@ -2,6 +2,8 @@
 #include "memutils.h"
 #include "string.h"
 #include <vector>
+#include <cstdio>
+#include <map>
 #include "assert.h"
 #include "stdlib.h"
 


### PR DESCRIPTION
wont build without these 
```
/home/lwss/Documents/Ape-ex-Abominations/modules/m0dular/utils/pattern_scan.cpp: In member function ‘uintptr_t pOperation::RunOp(uintptr_t)’:
/home/lwss/Documents/Ape-ex-Abominations/modules/m0dular/utils/pattern_scan.cpp:41:6: error: ‘printf’ was not declared in this scope
   41 |      printf("INVALID OPPPP!\n");
      |      ^~~~~~
/home/lwss/Documents/Ape-ex-Abominations/modules/m0dular/utils/pattern_scan.cpp:7:1: note: ‘printf’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
    6 | #include "stdlib.h"
  +++ |+#include <cstdio>
    7 | 
/home/lwss/Documents/Ape-ex-Abominations/modules/m0dular/utils/pattern_scan.cpp: At global scope:
/home/lwss/Documents/Ape-ex-Abominations/modules/m0dular/utils/pattern_scan.cpp:50:13: error: ‘map’ in namespace ‘std’ does not name a template type
   50 | static std::map<char, size_t> readSizes = {
      |             ^~~
/home/lwss/Documents/Ape-ex-Abominations/modules/m0dular/utils/pattern_scan.cpp:7:1: note: ‘std::map’ is defined in header ‘<map>’; did you forget to ‘#include <map>’?
    6 | #include "stdlib.h"
  +++ |+#include <map>
    7 | 
/home/lwss/Documents/Ape-ex-Abominations/modules/m0dular/utils/pattern_scan.cpp:56:2: warning: extra ‘;’ [-Wpedantic]
   56 | };
      |  ^
/home/lwss/Documents/Ape-ex-Abominations/modules/m0dular/utils/pattern_scan.cpp: In member function ‘uintptr_t pOperation::RunOp(uintptr_t)’:
/home/lwss/Documents/Ape-ex-Abominations/modules/m0dular/utils/pattern_scan.cpp:41:6: error: ‘printf’ was not declared in this scope
   41 |      printf("INVALID OPPPP!\n");
      |      ^~~~~~
/home/lwss/Documents/Ape-ex-Abominations/modules/m0dular/utils/pattern_scan.cpp:7:1: note: ‘printf’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
    6 | #include "stdlib.h"
  +++ |+#include <cstdio>
    7 | 
/home/lwss/Documents/Ape-ex-Abominations/modules/m0dular/utils/pattern_scan.cpp: At global scope:
/home/lwss/Documents/Ape-ex-Abominations/modules/m0dular/utils/pattern_scan.cpp:50:13: error: ‘map’ in namespace ‘std’ does not name a template type
   50 | static std::map<char, size_t> readSizes = {
      |             ^~~
/home/lwss/Documents/Ape-ex-Abominations/modules/m0dular/utils/pattern_scan.cpp:7:1: note: ‘std::map’ is defined in header ‘<map>’; did you forget to ‘#include <map>’?
    6 | #include "stdlib.h"
  +++ |+#include <map>

```